### PR TITLE
Make name revisions dynamic

### DIFF
--- a/design/source/kicad/cicada-2g/P-1000010_Okra Cicada 2G PCBA.kicad_pcb
+++ b/design/source/kicad/cicada-2g/P-1000010_Okra Cicada 2G PCBA.kicad_pcb
@@ -6,9 +6,9 @@
 
   (paper "A4")
   (title_block
-    (title "Cicada 4G")
+    (title "Cicada 2G")
     (date "2019-04-02")
-    (rev "0.1")
+    (rev "${PROJECT_REVISION}")
     (company "Alexey Zaytsev / Okra Solar")
   )
 

--- a/design/source/kicad/cicada-2g/P-1000010_Okra Cicada 2G PCBA.kicad_pcb
+++ b/design/source/kicad/cicada-2g/P-1000010_Okra Cicada 2G PCBA.kicad_pcb
@@ -4338,7 +4338,7 @@
   (gr_line (start 114 60) (end 148 60) (layer "Edge.Cuts") (width 0.15) (tstamp 8f7ca320-80a9-433c-bda6-615d275d617f))
   (gr_arc (start 111 63) (mid 111.87868 60.87868) (end 114 60) (layer "Edge.Cuts") (width 0.15) (tstamp ca5eb6fc-a206-440b-baf3-9c2223dfcfeb))
   (gr_line (start 119 125) (end 114 125) (layer "Edge.Cuts") (width 0.15) (tstamp ec53c537-bf0b-418e-a061-3dae5ec0ea04))
-  (gr_text "P-1000010-V3" (at 148.74 76.06 90) (layer "F.SilkS") (tstamp 00000000-0000-0000-0000-00005efba35a)
+  (gr_text "P-1000010-V${PROJECT_REVISION_MAJOR}" (at 148.74 76.06 90) (layer "F.SilkS") (tstamp 00000000-0000-0000-0000-00005efba35a)
     (effects (font (size 1.2 1.2) (thickness 0.3) italic) (justify left))
   )
   (gr_text "NET" (at 146.22 75.39 90) (layer "F.SilkS") (tstamp 00000000-0000-0000-0000-00005efba36a)

--- a/design/source/kicad/cicada-2g/P-1000010_Okra Cicada 2G PCBA.kicad_pro
+++ b/design/source/kicad/cicada-2g/P-1000010_Okra Cicada 2G PCBA.kicad_pro
@@ -440,5 +440,8 @@
       ""
     ]
   ],
-  "text_variables": {}
+  "text_variables": {
+    "PROJECT_REVISION": "3.2.1",
+    "PROJECT_REVISION_MAJOR": "3"
+  }
 }

--- a/design/source/kicad/cicada-2g/P-1000010_Okra Cicada 2G PCBA.kicad_sch
+++ b/design/source/kicad/cicada-2g/P-1000010_Okra Cicada 2G PCBA.kicad_sch
@@ -5,9 +5,9 @@
   (paper "A3")
 
   (title_block
-    (title "Ciacada 2G")
+    (title "Cicada 2G")
     (date "2020-05-15")
-    (rev "2.0")
+    (rev "${PROJECT_REVISION}")
     (company "Alexey Zaytsev / Okra Solar")
   )
 

--- a/design/source/kicad/cicada-4g/P-1000011_Okra Cicada 4G PCBA.kicad_pcb
+++ b/design/source/kicad/cicada-4g/P-1000011_Okra Cicada 4G PCBA.kicad_pcb
@@ -8,7 +8,7 @@
   (title_block
     (title "Cicada 4G")
     (date "2019-04-02")
-    (rev "0.1")
+    (rev "${PROJECT_REVISION}")
     (company "Alexey Zaytsev / Okra Solar")
   )
 

--- a/design/source/kicad/cicada-4g/P-1000011_Okra Cicada 4G PCBA.kicad_pcb
+++ b/design/source/kicad/cicada-4g/P-1000011_Okra Cicada 4G PCBA.kicad_pcb
@@ -5140,7 +5140,7 @@
   (gr_text "FW\nUPD\nONLY" (at 141.2 127) (layer "F.SilkS") (tstamp a66c0bf6-511b-4c2d-b8a3-8358407436c5)
     (effects (font (size 1.2 1.2) (thickness 0.17)) (justify right))
   )
-  (gr_text "Cicada 4G v2.0" (at 133 84.15 90) (layer "F.SilkS") (tstamp bda46e44-354f-4b61-8ed9-3011168ec799)
+  (gr_text "Cicada 4G v${PROJECT_REVISION}" (at 133 84.15 90) (layer "F.SilkS") (tstamp bda46e44-354f-4b61-8ed9-3011168ec799)
     (effects (font (size 1.8 1.8) (thickness 0.35) italic))
   )
   (gr_text "- 2 layer FR-4\n\n- 1oz outer copper\n\n\nImpedance controlleed 50R SE lines:\nCo-planar line, to be more independent of stackup.\nW=0.55mm\nS=0.16mm\nH=1.5mm\nEr = 4.5 - 4.7, but can prob be wider\n\n- total finished thickness: 1.6mm±0.2mm\n" (at 178.8 77.9) (layer "Cmts.User") (tstamp 421ca491-bf90-4184-b797-b27befd6ff90)

--- a/design/source/kicad/cicada-4g/P-1000011_Okra Cicada 4G PCBA.kicad_pro
+++ b/design/source/kicad/cicada-4g/P-1000011_Okra Cicada 4G PCBA.kicad_pro
@@ -437,5 +437,7 @@
       ""
     ]
   ],
-  "text_variables": {}
+  "text_variables": {
+    "PROJECT_REVISION": "2.0"
+  }
 }

--- a/design/source/kicad/cicada-4g/P-1000011_Okra Cicada 4G PCBA.kicad_sch
+++ b/design/source/kicad/cicada-4g/P-1000011_Okra Cicada 4G PCBA.kicad_sch
@@ -5,9 +5,9 @@
   (paper "A3")
 
   (title_block
-    (title "Ciacada 4G")
+    (title "Cicada 4G")
     (date "2020-05-15")
-    (rev "2.0")
+    (rev "${PROJECT_REVISION}")
     (company "Alexey Zaytsev / Okra Solar")
   )
 


### PR DESCRIPTION
Currently there is some inconsistency in the revisions and how they are used in the PCB's and schematic.

Goal of the PR is to have a single source of truth in the projects settings. Then all PCB's and schematics using the revision as a variable call.

**Rendered version of Cicada 2G:**
![cicada-4g_render_3d_high_quality](https://github.com/EnAccess/Cicada-GSM-HW/assets/14202480/fa0a3525-1ae8-4326-ba34-80389ec866e9)


**Rendered version of Cicada 4G:**
![cicada-4g_render_3d_high_quality](https://github.com/EnAccess/Cicada-GSM-HW/assets/14202480/f8e532cb-00f2-47b5-88a8-55b6111efbe7)
